### PR TITLE
Fix issue setting wifi SSID containing spaces, and update README.md e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A [windows executable](https://github.com/vporpo/q2radio/releases) can be found 
 $ ./q2radio        # List the current state of the radio and exit
 $ ./q2radio --list # List the current state of the radio and exit
 $ ./q2radio --side 0 --name "New Radio" --url "http://stream/url"
-$ ./q2radio --wifi-ssid "<SSID>" --wifi-key "<WIFI KEY>"
+$ ./q2radio --wifi-ssid <SSID> --wifi-key <WIFI KEY> (backslash-escape spaces and special characters)
 $ ./q2radio --power-on-volume 10   # Set the default volume (1 to 17)
 $ ./q2radio --passthru '<command>' # Pass <command> directly to radio. e.g., --passthru 'help'
 

--- a/src/q2radio.cpp
+++ b/src/q2radio.cpp
@@ -379,17 +379,15 @@ int main(int argc, char **argv) {
   // Set ssid
   if (args.ssid) {
     std::cerr << "Setting SSID to " << args.ssid << "\n";
-    sendStr(handle, args.ssid);
     std::stringstream ss;
-    ss << "spro 0 ssid " << args.ssid;
+    ss << "spro 0 ssid \"" << args.ssid << "\"";
     sendStr(handle, ss.str().c_str());
   }
   // Set key
   if (args.key) {
     std::cerr << "Setting KEY to " << args.key << "\n";
-    sendStr(handle, args.key);
     std::stringstream ss;
-    ss << "spro 0 keyval " << args.key;
+    ss << "spro 0 keyval \"" << args.key << "\"";
     sendStr(handle, ss.str().c_str());
   }
   int vol = args.powerOnVolume;


### PR DESCRIPTION
…xample

Before this change, setting an SSID containing escaped spaces would result in a single-quote and the first "word" being returned by q2radio --list Example:
q2radio --wifi-ssid some\ ssid\ with\ spaces --wifi-key dBd£g5GW5qS\!K92*P 2>&1 q2radio --list | grep ^SSID
SSID: val='some

The SSID must *not* be wrapped in quotes, and must have its spaces backslash escaped.

For consistency the same fix is applied to the wifi key, though this is less likely to have spaces in it.